### PR TITLE
fix(training): correct CLAP model parameter name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ docker_*.sh
 # Project documentation (private)
 CLAUDE.md
 claude.md
+BRANCH_STRATEGY.md
+branch_strategy.md

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -76,7 +76,7 @@ class CLAP2DiffusionTrainer:
         
         # Initialize CLAP audio encoder
         self.audio_encoder = CLAPAudioEncoder(
-            model_path=self.config['model'].get('clap_model', 'laion/larger_clap_music_and_speech')
+            model_name=self.config['model'].get('clap_model', 'laion/larger_clap_music_and_speech')
         )
         
         # Initialize audio adapter


### PR DESCRIPTION
- Change model_path to model_name in CLAPAudioEncoder initialization
- Update .gitignore for private documentation files